### PR TITLE
DEVOPS-626: Disable "full" in backtrace

### DIFF
--- a/src/plugins/abrt-action-generate-backtrace.c
+++ b/src/plugins/abrt-action-generate-backtrace.c
@@ -111,7 +111,7 @@ static char *get_backtrace(struct dump_dir *dd, const char *debuginfo_dirs)
     /* Limit bt depth. With no limit, gdb sometimes OOMs the machine */
     unsigned bt_depth = 2048;
     const char *thread_apply_all = "thread apply all";
-    const char *full = " full";
+    const char *full = "";
     char *bt = NULL;
     while (1)
     {


### PR DESCRIPTION
gdb was choking on register arguments/vars sometimes resulting in
truncated stack traces.  The stack/register values end up being
optimized out any way so they aren't always that useful.
